### PR TITLE
Set pipeline_artifact for use in model_artifact.

### DIFF
--- a/demo1.ipynb
+++ b/demo1.ipynb
@@ -853,7 +853,9 @@
     "ml_repository_client.authorize(username, password)\n",
     "\n",
     "#Deploy a new model.  I renamed the existing model as it has already been created above\n",
-    "model_artifact = MLRepositoryArtifact(model_rf, training_data=train_data, name=\"Heart Failure Prediction Model V2\")"
+    "pipeline_artifact = MLRepositoryArtifact(pipeline_rf, name=\"pipeline\")\n",
+    "\n",
+    "model_artifact = MLRepositoryArtifact(model_rf, training_data=train_data, name=\"Heart Failure Prediction Model\", pipeline_artifact=pipeline_artifact)"
    ]
   },
   {


### PR DESCRIPTION
We must first set the pipeline_artifact and then pass this
in as a parameter to MLRepositoryArtifact() or we will get
a Value Error.

Closes: #6