### PR TITLE
Fixing index issues

### DIFF
--- a/notebooks/predictiveModel.ipynb
+++ b/notebooks/predictiveModel.ipynb
@@ -595,7 +595,7 @@
     "predictions = client.deployments.score(scoring_endpoint, scoring_payload)\n",
     "\n",
     "print(json.dumps(predictions, indent=2))\n",
-    "print(predictions['values'][0][18])"
+    "print(predictions['values'][0][17])"
    ]
   },
   {
@@ -612,7 +612,7 @@
    "outputs": [],
    "source": [
     "print('Is a 44 year old female that smokes with a low BMI at risk of Heart Failure?: {}'.format(client.deployments.score(scoring_endpoint, scoring_payload)\n",
-    "['values'][0][18]))"
+    "['values'][0][17]))"
    ]
   }
  ],

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -91,9 +91,9 @@ var	ResultsCtrl = ['$scope',	'$modalInstance',	'rspHeader', 'rspData', function 
 
    // Format confidence
     if (rspData.values[0][17] == 1)  // CONFIDENCE
-       confidence = (rspData.values[0][16][1] * 100).toFixed(2) + '%';
+       confidence = (rspData.values[0][15][1] * 100).toFixed(2) + '%';
     else
-	   confidence = (rspData.values[0][16][0] * 100).toFixed(2) + '%';
+	   confidence = (rspData.values[0][15][0] * 100).toFixed(2) + '%';
 
 	formattedData.push(confidence);
 


### PR DESCRIPTION
In walking through this lab to ensure it's up to speed for a customer, I noticed that there were some index errors that gave unfavorable results.

First, in the Jupyter notebook, the indices `[0][18]` used to examine the response from the Watson Machine Learning service should instead be `[0][17]` to show the correct data. I switched these, and the example works like so:
![image](https://user-images.githubusercontent.com/2584705/69108230-a96b0c00-0a39-11ea-8e52-4e77f7f902c0.png)

Additionally, this means that the web app, when deployed, references the incorrect node in the JSON response after making a prediction. I've corrected this issue and tested my results like so:
![image](https://user-images.githubusercontent.com/2584705/69108195-9821ff80-0a39-11ea-9d28-9c2b5bfad024.png)
